### PR TITLE
npm run start: npx webpack && docker build && docker run

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "start": "webpack-serve --open",
+    "start": "npx webpack && docker build -f nginx.Dockerfile -t dashboard . && docker run --rm --name dashboard -p443:443 -p80:80 dashboard",
     "serve": "webpack serve",
     "pack": "webpack --mode production",
     "prettier-format": "prettier --config .prettierrc 'src/**/*.ts' --write"


### PR DESCRIPTION
Currently `npm run start` doesn't work, and I don't know how to fix it within the webpack realm. So I switched to the tools I know better – docker + nginx.